### PR TITLE
feat(userdata):  add userdata feature parsing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,65 @@
+# Copilot Instructions for kubevirt-vm-feature-manager
+
+## Purpose & Shape
+- Mutating admission webhook for KubeVirt VMs that turns simple annotations into VM spec mutations (nested virt, vBIOS injection via hook sidecar, PCI passthrough, GPU device plugin).
+- Core flow: HTTP /mutate → decode AdmissionReview → build mutations via features → return JSONPatch replacing `/spec` and `/metadata/annotations`.
+- Key packages: `pkg/webhook` (server, handler, mutator), `pkg/features` (feature implementations), `pkg/config` (env/flags), `pkg/utils` (constants/helpers).
+
+## Where Things Live
+- Entrypoint: `cmd/webhook/main.go` (config, k8s client, feature list, server start).
+- Webhook: `pkg/webhook/{server.go,handler.go,mutator.go}`; health endpoints at `/healthz` and `/readyz` over TLS.
+- Features: `pkg/features/*.go` implement `Feature` (Name, IsEnabled, Validate, Apply). Examples: `nested_virt.go`, `vbios_injection.go`, `pci_passthrough.go`, `gpu_device_plugin.go`.
+- Conventions: Annotation namespace `vm-feature-manager.io/*`; tracking annotations use `*-applied`; constants in `pkg/utils/constants.go`.
+
+## Build & Test
+- Common targets (see `Makefile`):
+  - `make build` (binary `./webhook`), `make test` (unit), `make test-integration` (envtest), `make test-all`, `make test-coverage`.
+  - Tools: `make install-tools` and `make setup-envtest` (once) for integration tests.
+- Run tests with verbose/watch: `make test-verbose`, `ginkgo watch -r --skip-package=test/integration`.
+
+## Run & Debug Locally
+- Needs TLS certs; server reads from `CERT_DIR` (default `/etc/webhook/certs`).
+- Quick run:
+  - `PORT=8443 CERT_DIR=./certs LOG_LEVEL=debug ./webhook`
+- Flags (override env): `--port`, `--cert-dir`, `--error-handling`, `--log-level`.
+- Logs via zap (controller-runtime); `debug` level logs feature detection details.
+
+## Feature Pattern (add a new feature)
+- Implement `features.Feature` with: `Name()`, `IsEnabled(vm)`, `Validate(ctx, vm, client)`, `Apply(ctx, vm, client)` returning `*features.MutationResult`.
+- Define input/tracking annotation keys in `pkg/utils/constants.go`.
+- Register in `cmd/webhook/main.go` by appending to `featureList` (order matters if features may interact).
+- Examples to mirror:
+  - Nested virt adds `CPU.Features` and initializes missing structs.
+  - PCI/GPU validate input and error if `vm.Spec.Template` is nil (tests expect this).
+  - vBIOS adds a `Volume` and a KubeVirt hook sidecar annotation on the VM template.
+
+## Annotations & Error Modes
+- Inputs: `nested-virt`, `vbios-injection`, `pci-passthrough` (JSON: `{ "devices": ["0000:00:02.0"] }`), `gpu-device-plugin`.
+- Tracking: `*-applied` annotations added when `AddTrackingAnnotations=true` (default).
+- Error handling (global): `ERROR_HANDLING_MODE=reject|allow-and-log|strip-label`.
+  - `strip-label` removes the failing feature's input annotation and allows admission.
+- vBIOS override sidecar image: `vm-feature-manager.io/sidecar-image`.
+- **Userdata directives**: Features can be specified in cloud-init userdata using `# @kubevirt-feature: <feature-name>=<value>` (e.g., `# @kubevirt-feature: nested-virt=enabled`). Supports plain text, base64, and Secret references. Annotations take precedence over userdata directives.
+
+## Helm & Deployment
+- Chart: `deploy/helm/vm-feature-manager`. Values map to flags: `.webhook.port`, `.webhook.certDir`, `.errorHandling.mode`, `.logLevel`; extra env can be injected via `.Values.env`.
+- TLS via cert-manager (default, CA injection on `MutatingWebhookConfiguration`) or manual `caBundle`.
+- Mutating webhook path is `/mutate`; operations: CREATE/UPDATE on `kubevirt.io/v1` `VirtualMachine`.
+
+## Gotchas & Tips
+- Patch builder currently replaces `/spec` and `/metadata/annotations` wholesale; use fine-grained RFC6902 ops if you extend patching.
+- Some features initialize missing structs (nested virt); others require an existing `spec.template` (PCI/GPU/vBIOS). Handle nils carefully to match tests.
+- Config has per-feature toggles, but only nested virt reads `Enabled` directly; if you add toggles, wire them explicitly in feature code.
+- Use `setup-envtest` + `make test-integration` for API-driven tests; unit tests use Ginkgo v2 + Gomega.
+
+## Quick Examples
+- Enable nested virt: add annotation `vm-feature-manager.io/nested-virt: "enabled"`.
+- Add PCI passthrough: `vm-feature-manager.io/pci-passthrough: '{"devices":["0000:00:02.0"]}'`.
+- Enable GPU plugin: `vm-feature-manager.io/gpu-device-plugin: "nvidia.com/gpu"`.
+- vBIOS injection: `vm-feature-manager.io/vbios-injection: "<configmap>"` (+ optional `sidecar-image`).
+- Userdata directives (for Rancher/Harvester):
+  ```yaml
+  #cloud-config
+  # @kubevirt-feature: nested-virt=enabled
+  # @kubevirt-feature: gpu-device-plugin=nvidia.com/gpu
+  ```

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -543,6 +543,11 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]
+
+  # Read secrets for userdata directives
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
   
   # Read KubeVirt resource for version detection
   - apiGroups: ["kubevirt.io"]
@@ -571,6 +576,11 @@ rules:
 - **Timeout**: 10s timeout to prevent hanging admissions
 - **Reinvocation**: `reinvocationPolicy: IfNeeded` (allow other webhooks to run first)
 - **Scope**: Only mutate VirtualMachine resources in configured namespaces
+
+### Userdata Secret Access
+
+- The webhook reads secrets referenced by cloud-init in the VM's namespace without additional labels or annotations.
+- Recommendation: Use namespace-scoped RBAC to limit which secrets are readable; operational assumption is if you can create a VM in a namespace, you can read its referenced Secret.
 
 ## Code Quality Standards
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,38 @@ spec:
   # ... rest of VM spec
 ```
 
+### Userdata Directives (Rancher/Harvester)
+
+For environments where VM annotations aren't accessible (like Rancher/Harvester), you can use **userdata directives** in cloud-init:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: my-vm
+spec:
+  template:
+    spec:
+      volumes:
+        - name: cloudinit
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              # @kubevirt-feature: nested-virt=enabled
+              # @kubevirt-feature: gpu-device-plugin=nvidia.com/gpu
+              # @kubevirt-feature: pci-passthrough={"devices":["0000:00:02.0"]}
+              users:
+                - name: ubuntu
+                  sudo: ALL=(ALL) NOPASSWD:ALL
+```
+
+**Supported formats:**
+- Plain text: `userData: |`
+- Base64: `userDataBase64: <base64-encoded>`
+- Secret reference: `userDataSecretRef: {name: my-secret}`
+
+**Note:** VM annotations take precedence over userdata directives.
+
 ### Installation
 
 #### Using Helm (Recommended)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ spec:
 - Base64: `userDataBase64: <base64-encoded>`
 - Secret reference: `userDataSecretRef: {name: my-secret}`
 
+Security:
+- The webhook reads referenced Secrets in the VM namespace for userdata without additional labels or annotations.
+- Recommendation: Use namespace-scoped RBAC to limit which secrets are readable; if you can create a VM in the namespace, you are assumed to have permission to read its referenced Secret.
+
 **Note:** VM annotations take precedence over userdata directives.
 
 ### Installation

--- a/examples/vm-with-userdata-features.yaml
+++ b/examples/vm-with-userdata-features.yaml
@@ -1,0 +1,196 @@
+---
+# Example VirtualMachine using userdata directives for feature activation
+# This approach works in Rancher/Harvester where VM annotations aren't directly accessible
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: ubuntu-vm-with-userdata-features
+  namespace: default
+  labels:
+    app: ubuntu-vm
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: ubuntu-vm-with-userdata-features
+    spec:
+      domain:
+        devices:
+          disks:
+            - name: containerdisk
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              masquerade: {}
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 2
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/containerdisks/ubuntu:22.04
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              # VM Feature Manager directives - processed by webhook before VM creation
+              # @kubevirt-feature: nested-virt=enabled
+              # @kubevirt-feature: gpu-device-plugin=nvidia.com/gpu
+              
+              # Standard cloud-init configuration
+              hostname: ubuntu-vm
+              users:
+                - name: ubuntu
+                  sudo: ALL=(ALL) NOPASSWD:ALL
+                  shell: /bin/bash
+                  ssh_authorized_keys:
+                    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC... your-ssh-key-here
+              
+              packages:
+                - qemu-guest-agent
+              
+              runcmd:
+                - systemctl enable qemu-guest-agent
+                - systemctl start qemu-guest-agent
+---
+# Example with base64-encoded userdata
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: ubuntu-vm-base64-userdata
+  namespace: default
+spec:
+  running: false
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: ubuntu-vm-base64-userdata
+    spec:
+      domain:
+        devices:
+          disks:
+            - name: containerdisk
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+        resources:
+          requests:
+            memory: 2Gi
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/containerdisks/ubuntu:22.04
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            # Base64-encoded userdata with feature directives
+            # Decoded content:
+            # #cloud-config
+            # # @kubevirt-feature: nested-virt=enabled
+            # # @kubevirt-feature: pci-passthrough={"devices":["0000:00:02.0"]}
+            # hostname: ubuntu-vm
+            userDataBase64: I2Nsb3VkLWNvbmZpZwojIEBrdWJldmlydC1mZWF0dXJlOiBuZXN0ZWQtdmlydD1lbmFibGVkCiMgQGt1YmV2aXJ0LWZlYXR1cmU6IHBjaS1wYXNzdGhyb3VnaD17ImRldmljZXMiOlsiMDAwMDowMDowMi4wIl19Cmhvc3RuYW1lOiB1YnVudHUtdm0K
+---
+# Example with Secret reference for userdata
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vm-userdata-with-features
+  namespace: default
+type: Opaque
+stringData:
+  userdata: |
+    #cloud-config
+    # @kubevirt-feature: nested-virt=enabled
+    # @kubevirt-feature: vbios-injection=my-vbios-configmap
+    hostname: ubuntu-vm
+    users:
+      - name: ubuntu
+        sudo: ALL=(ALL) NOPASSWD:ALL
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: ubuntu-vm-secret-userdata
+  namespace: default
+spec:
+  running: false
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: ubuntu-vm-secret-userdata
+    spec:
+      domain:
+        devices:
+          disks:
+            - name: containerdisk
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+        resources:
+          requests:
+            memory: 2Gi
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/containerdisks/ubuntu:22.04
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            # Reference to Secret containing userdata with feature directives
+            userDataSecretRef:
+              name: vm-userdata-with-features
+---
+# Example combining annotation and userdata features
+# Note: Annotations take precedence over userdata directives
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: ubuntu-vm-mixed-features
+  namespace: default
+  annotations:
+    # This annotation will override the userdata directive
+    vm-feature-manager.io/nested-virt: "enabled"
+spec:
+  running: false
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: ubuntu-vm-mixed-features
+    spec:
+      domain:
+        devices:
+          disks:
+            - name: containerdisk
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+        resources:
+          requests:
+            memory: 2Gi
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/containerdisks/ubuntu:22.04
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              # This will be ignored because annotation exists
+              # @kubevirt-feature: nested-virt=disabled
+              # This will be applied (no annotation override)
+              # @kubevirt-feature: gpu-device-plugin=nvidia.com/gpu
+              hostname: ubuntu-vm

--- a/pkg/userdata/parser.go
+++ b/pkg/userdata/parser.go
@@ -1,0 +1,149 @@
+// Package userdata provides parsing of feature directives from VM userdata.
+// It supports extracting @kubevirt-feature: directives from cloud-init userdata
+// in various formats: plain text, base64-encoded, or Secret references.
+package userdata
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"regexp"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// featureDirectiveRegex matches lines like:
+// # @kubevirt-feature: nested-virt=enabled
+// # @kubevirt-feature: pci-passthrough={"devices":["0000:00:02.0"]}
+var featureDirectiveRegex = regexp.MustCompile(`(?m)^\s*#\s*@kubevirt-feature:\s*([a-z0-9-]+)\s*=\s*(.+?)\s*$`)
+
+// Parser extracts feature directives from VM userdata
+type Parser struct {
+	client client.Client
+}
+
+// NewParser creates a new userdata parser
+func NewParser(client client.Client) *Parser {
+	return &Parser{
+		client: client,
+	}
+}
+
+// ParseFeatures extracts feature directives from VM userdata volumes
+// and returns them as a map of annotation key -> value
+func (p *Parser) ParseFeatures(ctx context.Context, vm *kubevirtv1.VirtualMachine) (map[string]string, error) {
+	logger := log.FromContext(ctx)
+	features := make(map[string]string)
+
+	if vm.Spec.Template == nil {
+		return features, nil
+	}
+
+	// Iterate through volumes looking for cloud-init userdata
+	for _, volume := range vm.Spec.Template.Spec.Volumes {
+		var userData string
+		var err error
+
+		// Handle CloudInitNoCloud
+		if volume.CloudInitNoCloud != nil {
+			userData, err = p.extractUserData(ctx, vm, volume.CloudInitNoCloud.UserData, volume.CloudInitNoCloud.UserDataBase64, volume.CloudInitNoCloud.UserDataSecretRef)
+			if err != nil {
+				logger.Error(err, "Failed to extract userdata from CloudInitNoCloud", "volume", volume.Name)
+				continue
+			}
+		}
+
+		// Handle CloudInitConfigDrive
+		if volume.CloudInitConfigDrive != nil {
+			userData, err = p.extractUserData(ctx, vm, volume.CloudInitConfigDrive.UserData, volume.CloudInitConfigDrive.UserDataBase64, volume.CloudInitConfigDrive.UserDataSecretRef)
+			if err != nil {
+				logger.Error(err, "Failed to extract userdata from CloudInitConfigDrive", "volume", volume.Name)
+				continue
+			}
+		}
+
+		// Parse feature directives from userdata
+		if userData != "" {
+			volumeFeatures := p.parseDirectives(userData)
+			for k, v := range volumeFeatures {
+				features[k] = v
+			}
+		}
+	}
+
+	if len(features) > 0 {
+		logger.Info("Extracted feature directives from userdata", "features", features)
+	}
+
+	return features, nil
+}
+
+// extractUserData extracts userdata from plain text, base64, or secret reference
+func (p *Parser) extractUserData(ctx context.Context, vm *kubevirtv1.VirtualMachine, plainText, base64Text string, secretRef *corev1.LocalObjectReference) (string, error) {
+	// Priority: plain text -> base64 -> secret
+	if plainText != "" {
+		return plainText, nil
+	}
+
+	if base64Text != "" {
+		decoded, err := base64.StdEncoding.DecodeString(base64Text)
+		if err != nil {
+			return "", fmt.Errorf("failed to decode base64 userdata: %w", err)
+		}
+		return string(decoded), nil
+	}
+
+	if secretRef != nil {
+		return p.fetchSecretUserData(ctx, vm.Namespace, secretRef.Name)
+	}
+
+	return "", nil
+}
+
+// fetchSecretUserData fetches userdata from a Kubernetes Secret
+func (p *Parser) fetchSecretUserData(ctx context.Context, namespace, secretName string) (string, error) {
+	logger := log.FromContext(ctx)
+
+	secret := &corev1.Secret{}
+	key := client.ObjectKey{
+		Namespace: namespace,
+		Name:      secretName,
+	}
+
+	if err := p.client.Get(ctx, key, secret); err != nil {
+		return "", fmt.Errorf("failed to fetch secret %s/%s: %w", namespace, secretName, err)
+	}
+
+	// Try common userdata keys
+	for _, key := range []string{"userdata", "userData", "user-data"} {
+		if data, ok := secret.Data[key]; ok {
+			logger.Info("Found userdata in secret", "secret", secretName, "key", key)
+			return string(data), nil
+		}
+	}
+
+	return "", fmt.Errorf("no userdata found in secret %s/%s (tried keys: userdata, userData, user-data)", namespace, secretName)
+}
+
+// parseDirectives extracts @kubevirt-feature directives from userdata text
+func (p *Parser) parseDirectives(userData string) map[string]string {
+	features := make(map[string]string)
+
+	matches := featureDirectiveRegex.FindAllStringSubmatch(userData, -1)
+	for _, match := range matches {
+		if len(match) == 3 {
+			featureName := strings.TrimSpace(match[1])
+			featureValue := strings.TrimSpace(match[2])
+
+			// Map feature names to annotation keys
+			annotationKey := fmt.Sprintf("vm-feature-manager.io/%s", featureName)
+			features[annotationKey] = featureValue
+		}
+	}
+
+	return features
+}

--- a/pkg/userdata/parser.go
+++ b/pkg/userdata/parser.go
@@ -139,6 +139,10 @@ func (p *Parser) fetchSecretUserData(ctx context.Context, namespace, secretName 
 func (p *Parser) parseDirectives(userData string) map[string]string {
 	features := make(map[string]string)
 
+	// Reject overly large userdata to prevent resource exhaustion
+	if len(userData) > 65536 { // 64KB limit
+		return features
+	}
 	matches := featureDirectiveRegex.FindAllStringSubmatch(userData, -1)
 	for _, match := range matches {
 		if len(match) == 3 {

--- a/pkg/userdata/parser.go
+++ b/pkg/userdata/parser.go
@@ -71,6 +71,9 @@ func (p *Parser) ParseFeatures(ctx context.Context, vm *kubevirtv1.VirtualMachin
 		if userData != "" {
 			volumeFeatures := p.parseDirectives(userData)
 			for k, v := range volumeFeatures {
+				if prev, exists := features[k]; exists {
+					logger.Info("Overwriting feature key from previous volume", "key", k, "previousValue", prev, "newValue", v, "volume", volume.Name)
+				}
 				features[k] = v
 			}
 		}

--- a/pkg/userdata/parser.go
+++ b/pkg/userdata/parser.go
@@ -108,9 +108,10 @@ func (p *Parser) extractUserData(ctx context.Context, vm *kubevirtv1.VirtualMach
 	return "", nil
 }
 
-// fetchSecretUserData fetches userdata from a Kubernetes Secret
-// Security: Only secrets labeled with "vm-feature-manager.io/userdata=allowed" can be accessed
-// to prevent information disclosure from arbitrary secrets
+// fetchSecretUserData fetches userdata from a Kubernetes Secret.
+// Security: The webhook can read any Secret in the same namespace as the VM.
+// This assumes that if the webhook can mutate a VM in a namespace,
+// it is permitted to read the referenced Secret in that namespace.
 func (p *Parser) fetchSecretUserData(ctx context.Context, namespace, secretName string) (string, error) {
 	logger := log.FromContext(ctx)
 

--- a/pkg/userdata/parser_test.go
+++ b/pkg/userdata/parser_test.go
@@ -1,0 +1,474 @@
+package userdata_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/jaevans/kubevirt-vm-feature-manager/pkg/userdata"
+)
+
+var _ = Describe("Userdata Parser", func() {
+	var (
+		ctx        context.Context
+		fakeClient client.Client
+		parser     *userdata.Parser
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme := setupScheme()
+		fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+		parser = userdata.NewParser(fakeClient)
+	})
+
+	Describe("ParseFeatures", func() {
+		Context("with plain text userdata", func() {
+			It("should extract single feature directive", func() {
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinit",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserData: `#cloud-config
+# @kubevirt-feature: nested-virt=enabled
+users:
+  - name: ubuntu
+`,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				features, err := parser.ParseFeatures(ctx, vm)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(features).To(HaveKeyWithValue("vm-feature-manager.io/nested-virt", "enabled"))
+			})
+
+			It("should extract multiple feature directives", func() {
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinit",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserData: `#cloud-config
+# @kubevirt-feature: nested-virt=enabled
+# @kubevirt-feature: gpu-device-plugin=nvidia.com/gpu
+# @kubevirt-feature: pci-passthrough={"devices":["0000:00:02.0"]}
+users:
+  - name: ubuntu
+`,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				features, err := parser.ParseFeatures(ctx, vm)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(features).To(HaveLen(3))
+				Expect(features).To(HaveKeyWithValue("vm-feature-manager.io/nested-virt", "enabled"))
+				Expect(features).To(HaveKeyWithValue("vm-feature-manager.io/gpu-device-plugin", "nvidia.com/gpu"))
+				Expect(features).To(HaveKeyWithValue("vm-feature-manager.io/pci-passthrough", `{"devices":["0000:00:02.0"]}`))
+			})
+
+			It("should handle directives with varying whitespace", func() {
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinit",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserData: `#cloud-config
+#@kubevirt-feature:nested-virt=enabled
+  # @kubevirt-feature: gpu-device-plugin = nvidia.com/gpu  
+#    @kubevirt-feature:   pci-passthrough  =  {"devices":["0000:00:02.0"]}
+`,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				features, err := parser.ParseFeatures(ctx, vm)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(features).To(HaveLen(3))
+			})
+
+			It("should ignore non-matching lines", func() {
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinit",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserData: `#cloud-config
+# This is a regular comment
+# @kubevirt-feature: nested-virt=enabled
+# Another regular comment
+# @not-a-feature: something=else
+`,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				features, err := parser.ParseFeatures(ctx, vm)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(features).To(HaveLen(1))
+				Expect(features).To(HaveKeyWithValue("vm-feature-manager.io/nested-virt", "enabled"))
+			})
+		})
+
+		Context("with base64-encoded userdata", func() {
+			It("should decode and extract features", func() {
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinit",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserDataBase64: "I2Nsb3VkLWNvbmZpZwojIEBrdWJldmlydC1mZWF0dXJlOiBuZXN0ZWQtdmlydD1lbmFibGVkCnVzZXJzOgogIC0gbmFtZTogdWJ1bnR1Cg==",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				features, err := parser.ParseFeatures(ctx, vm)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(features).To(HaveKeyWithValue("vm-feature-manager.io/nested-virt", "enabled"))
+			})
+
+			It("should handle invalid base64", func() {
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinit",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserDataBase64: "not-valid-base64!!!",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				features, err := parser.ParseFeatures(ctx, vm)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(features).To(BeEmpty())
+			})
+		})
+
+		Context("with secret reference", func() {
+			It("should fetch and parse userdata from secret", func() {
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"userdata": []byte(`#cloud-config
+# @kubevirt-feature: nested-virt=enabled
+users:
+  - name: ubuntu
+`),
+					},
+				}
+				Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinit",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserDataSecretRef: &corev1.LocalObjectReference{
+													Name: "test-secret",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				features, err := parser.ParseFeatures(ctx, vm)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(features).To(HaveKeyWithValue("vm-feature-manager.io/nested-virt", "enabled"))
+			})
+
+			It("should try multiple common keys in secret", func() {
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"user-data": []byte(`#cloud-config
+# @kubevirt-feature: nested-virt=enabled
+`),
+					},
+				}
+				Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinit",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserDataSecretRef: &corev1.LocalObjectReference{
+													Name: "test-secret",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				features, err := parser.ParseFeatures(ctx, vm)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(features).To(HaveKeyWithValue("vm-feature-manager.io/nested-virt", "enabled"))
+			})
+
+			It("should handle missing secret", func() {
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinit",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserDataSecretRef: &corev1.LocalObjectReference{
+													Name: "missing-secret",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				features, err := parser.ParseFeatures(ctx, vm)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(features).To(BeEmpty())
+			})
+		})
+
+		Context("with CloudInitConfigDrive", func() {
+			It("should extract features from ConfigDrive userdata", func() {
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinit",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitConfigDrive: &kubevirtv1.CloudInitConfigDriveSource{
+												UserData: `#cloud-config
+# @kubevirt-feature: nested-virt=enabled
+`,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				features, err := parser.ParseFeatures(ctx, vm)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(features).To(HaveKeyWithValue("vm-feature-manager.io/nested-virt", "enabled"))
+			})
+		})
+
+		Context("with multiple volumes", func() {
+			It("should merge features from all volumes", func() {
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinit1",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserData: `# @kubevirt-feature: nested-virt=enabled`,
+											},
+										},
+									},
+									{
+										Name: "cloudinit2",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitConfigDrive: &kubevirtv1.CloudInitConfigDriveSource{
+												UserData: `# @kubevirt-feature: gpu-device-plugin=nvidia.com/gpu`,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				features, err := parser.ParseFeatures(ctx, vm)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(features).To(HaveLen(2))
+				Expect(features).To(HaveKeyWithValue("vm-feature-manager.io/nested-virt", "enabled"))
+				Expect(features).To(HaveKeyWithValue("vm-feature-manager.io/gpu-device-plugin", "nvidia.com/gpu"))
+			})
+		})
+
+		Context("with no userdata", func() {
+			It("should return empty map for VM without template", func() {
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+					},
+				}
+
+				features, err := parser.ParseFeatures(ctx, vm)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(features).To(BeEmpty())
+			})
+
+			It("should return empty map for VM without volumes", func() {
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtv1.Volume{},
+							},
+						},
+					},
+				}
+
+				features, err := parser.ParseFeatures(ctx, vm)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(features).To(BeEmpty())
+			})
+		})
+	})
+})
+
+// setupScheme creates a scheme with required types for testing
+func setupScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = kubevirtv1.AddToScheme(scheme)
+	return scheme
+}

--- a/pkg/userdata/userdata_suite_test.go
+++ b/pkg/userdata/userdata_suite_test.go
@@ -1,0 +1,13 @@
+package userdata_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUserdata(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Userdata Suite")
+}

--- a/pkg/webhook/mutator.go
+++ b/pkg/webhook/mutator.go
@@ -62,21 +62,27 @@ func (m *Mutator) Handle(ctx context.Context, req *admissionv1.AdmissionRequest)
 		"namespace", vm.Namespace,
 		"operation", req.Operation)
 
-	// Parse userdata for feature directives and merge into annotations
+	// Parse userdata for feature directives (non-fatal if fails)
 	userdataFeatures, err := m.userdataParser.ParseFeatures(ctx, vm)
 	if err != nil {
 		logger.Error(err, "Failed to parse userdata features")
-		// Non-fatal: continue with annotation-based features
+		// Non-fatal: continue with annotation-based features only
+		userdataFeatures = nil
 	} else if len(userdataFeatures) > 0 {
 		logger.Info("Found feature directives in userdata", "features", userdataFeatures)
-		
-		// Merge userdata features into annotations (annotations take precedence)
-		if vm.Annotations == nil {
-			vm.Annotations = make(map[string]string)
+	}
+
+	// Create a copy to mutate
+	mutatedVM := vm.DeepCopy()
+
+	// Merge userdata features into mutated VM's annotations (annotations take precedence)
+	if len(userdataFeatures) > 0 {
+		if mutatedVM.Annotations == nil {
+			mutatedVM.Annotations = make(map[string]string)
 		}
 		for key, value := range userdataFeatures {
-			if _, exists := vm.Annotations[key]; !exists {
-				vm.Annotations[key] = value
+			if _, exists := mutatedVM.Annotations[key]; !exists {
+				mutatedVM.Annotations[key] = value
 				logger.Info("Applied userdata feature directive", "key", key, "value", value)
 			} else {
 				logger.Info("Skipping userdata feature (annotation exists)", "key", key)
@@ -85,23 +91,20 @@ func (m *Mutator) Handle(ctx context.Context, req *admissionv1.AdmissionRequest)
 	}
 
 	// Log detailed feature detection information for debugging
-	m.logFeatureDetection(ctx, vm)
+	m.logFeatureDetection(ctx, mutatedVM)
 
-	// Check if any features are enabled
-	if !m.hasEnabledFeatures(vm) {
+	// Check if any features are enabled (check mutatedVM with merged userdata)
+	if !m.hasEnabledFeatures(mutatedVM) {
 		logger.Info("No features enabled for VM", "vm", vm.Name)
 		return m.allowResponse("No features requested"), nil
 	}
-
-	// Create a copy to mutate
-	mutatedVM := vm.DeepCopy()
 
 	// Apply features
 	appliedFeatures := []string{}
 	allAnnotations := make(map[string]string)
 
 	for _, feature := range m.features {
-		if !feature.IsEnabled(vm) {
+		if !feature.IsEnabled(mutatedVM) {
 			continue
 		}
 

--- a/pkg/webhook/mutator_test.go
+++ b/pkg/webhook/mutator_test.go
@@ -7,9 +7,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/jaevans/kubevirt-vm-feature-manager/pkg/config"
 	"github.com/jaevans/kubevirt-vm-feature-manager/pkg/features"
@@ -1029,6 +1031,599 @@ var _ = Describe("Mutator", func() {
 						resources := domain["resources"].(map[string]interface{})
 						limits := resources["limits"].(map[string]interface{})
 						Expect(limits).To(HaveKey("nvidia.com/gpu"))
+						break
+					}
+				}
+				Expect(foundSpecPatch).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("Userdata Feature Integration", func() {
+		Context("with userdata feature directives and no annotations", func() {
+			It("should apply features from userdata", func() {
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{},
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinit",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserData: `#cloud-config
+# @kubevirt-feature: nested-virt=enabled
+users:
+  - name: ubuntu
+`,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				vmBytes, err := json.Marshal(vm)
+				Expect(err).ToNot(HaveOccurred())
+
+				req := &admissionv1.AdmissionRequest{
+					UID:       "test-uid",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: vmBytes,
+					},
+				}
+
+				nestedVirtFeature := features.NewNestedVirtualization(&config.NestedVirtConfig{
+					Enabled:       true,
+					AutoDetectCPU: true,
+				}, utils.ConfigSourceAnnotations)
+				mutator = NewMutator(nil, cfg, []features.Feature{nestedVirtFeature})
+
+				response, err := mutator.Handle(ctx, req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+				Expect(response.Allowed).To(BeTrue())
+				Expect(response.Patch).ToNot(BeNil())
+				Expect(response.PatchType).ToNot(BeNil())
+				Expect(*response.PatchType).To(Equal(admissionv1.PatchTypeJSONPatch))
+
+				// Verify the patch contains CPU features from nested virt
+				var patchOps []map[string]interface{}
+				err = json.Unmarshal(response.Patch, &patchOps)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify spec patch contains CPU features
+				foundSpecPatch := false
+				for _, op := range patchOps {
+					if path, ok := op["path"].(string); ok && path == "/spec" {
+						foundSpecPatch = true
+						spec, ok := op["value"].(map[string]interface{})
+						Expect(ok).To(BeTrue(), "spec patch value should be a map")
+
+						template, ok := spec["template"].(map[string]interface{})
+						Expect(ok).To(BeTrue(), "template should exist in spec")
+						specMap, ok := template["spec"].(map[string]interface{})
+						Expect(ok).To(BeTrue(), "spec should exist in template")
+						domain, ok := specMap["domain"].(map[string]interface{})
+						Expect(ok).To(BeTrue(), "domain should exist in spec")
+						cpu, ok := domain["cpu"].(map[string]interface{})
+						Expect(ok).To(BeTrue(), "CPU should be present")
+						cpuFeatures, ok := cpu["features"].([]interface{})
+						Expect(ok).To(BeTrue(), "CPU features should be present")
+						Expect(cpuFeatures).ToNot(BeEmpty(), "CPU features should not be empty")
+						break
+					}
+				}
+				Expect(foundSpecPatch).To(BeTrue(), "should have a spec patch operation")
+
+				// Verify annotations patch contains both the merged userdata annotation and tracking annotation
+				foundAnnotationsPatch := false
+				for _, op := range patchOps {
+					if path, ok := op["path"].(string); ok && path == "/metadata/annotations" {
+						foundAnnotationsPatch = true
+						annotations, ok := op["value"].(map[string]interface{})
+						Expect(ok).To(BeTrue(), "annotations patch value should be a map")
+						// Should have the userdata-derived annotation merged in
+						Expect(annotations).To(HaveKey(utils.AnnotationNestedVirt))
+						Expect(annotations[utils.AnnotationNestedVirt]).To(Equal("enabled"))
+						// Should have tracking annotation
+						Expect(annotations).To(HaveKey(utils.AnnotationNestedVirtApplied))
+						break
+					}
+				}
+				Expect(foundAnnotationsPatch).To(BeTrue(), "should have an annotations patch operation")
+			})
+
+			It("should apply multiple features from userdata", func() {
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{},
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinit",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserData: `#cloud-config
+# @kubevirt-feature: nested-virt=enabled
+# @kubevirt-feature: gpu-device-plugin=nvidia.com/gpu
+users:
+  - name: ubuntu
+`,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				vmBytes, err := json.Marshal(vm)
+				Expect(err).ToNot(HaveOccurred())
+
+				req := &admissionv1.AdmissionRequest{
+					UID:       "test-uid",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: vmBytes,
+					},
+				}
+
+				nestedVirtFeature := features.NewNestedVirtualization(&config.NestedVirtConfig{
+					Enabled:       true,
+					AutoDetectCPU: true,
+				}, utils.ConfigSourceAnnotations)
+				gpuFeature := features.NewGpuDevicePlugin(utils.ConfigSourceAnnotations)
+				mutator = NewMutator(nil, cfg, []features.Feature{nestedVirtFeature, gpuFeature})
+
+				response, err := mutator.Handle(ctx, req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+				Expect(response.Allowed).To(BeTrue())
+				Expect(response.Patch).ToNot(BeNil())
+
+				// Verify the patch contains both CPU features and GPU resource limits
+				var patchOps []map[string]interface{}
+				err = json.Unmarshal(response.Patch, &patchOps)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Check annotations patch has both merged annotations
+				for _, op := range patchOps {
+					if path, ok := op["path"].(string); ok && path == "/metadata/annotations" {
+						annotations, ok := op["value"].(map[string]interface{})
+						Expect(ok).To(BeTrue())
+						Expect(annotations).To(HaveKey(utils.AnnotationNestedVirt))
+						Expect(annotations).To(HaveKey(utils.AnnotationGpuDevicePlugin))
+						Expect(annotations).To(HaveKey(utils.AnnotationNestedVirtApplied))
+						Expect(annotations).To(HaveKey(utils.AnnotationGpuDevicePluginApplied))
+						break
+					}
+				}
+			})
+		})
+
+		Context("with both userdata features and annotations", func() {
+			It("should give precedence to annotations over userdata", func() {
+				// VM has annotation with different value than userdata
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+						Annotations: map[string]string{
+							// Annotation specifies a different GPU than userdata
+							utils.AnnotationGpuDevicePlugin: "amd.com/gpu",
+						},
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{},
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinit",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserData: `#cloud-config
+# @kubevirt-feature: gpu-device-plugin=nvidia.com/gpu
+users:
+  - name: ubuntu
+`,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				vmBytes, err := json.Marshal(vm)
+				Expect(err).ToNot(HaveOccurred())
+
+				req := &admissionv1.AdmissionRequest{
+					UID:       "test-uid",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: vmBytes,
+					},
+				}
+
+				gpuFeature := features.NewGpuDevicePlugin(utils.ConfigSourceAnnotations)
+				mutator = NewMutator(nil, cfg, []features.Feature{gpuFeature})
+
+				response, err := mutator.Handle(ctx, req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+				Expect(response.Allowed).To(BeTrue())
+				Expect(response.Patch).ToNot(BeNil())
+
+				// Verify the patch uses the annotation value (amd.com/gpu), not userdata value (nvidia.com/gpu)
+				var patchOps []map[string]interface{}
+				err = json.Unmarshal(response.Patch, &patchOps)
+				Expect(err).ToNot(HaveOccurred())
+
+				foundSpecPatch := false
+				for _, op := range patchOps {
+					if path, ok := op["path"].(string); ok && path == "/spec" {
+						foundSpecPatch = true
+						spec := op["value"].(map[string]interface{})
+						template := spec["template"].(map[string]interface{})
+						specMap := template["spec"].(map[string]interface{})
+						domain := specMap["domain"].(map[string]interface{})
+						resources := domain["resources"].(map[string]interface{})
+						limits := resources["limits"].(map[string]interface{})
+						// Annotation value should take precedence
+						Expect(limits).To(HaveKey("amd.com/gpu"), "annotation value should be used")
+						Expect(limits).ToNot(HaveKey("nvidia.com/gpu"), "userdata value should be overridden")
+						break
+					}
+				}
+				Expect(foundSpecPatch).To(BeTrue())
+			})
+
+			It("should merge non-conflicting features from both sources", func() {
+				// Annotation has nested-virt, userdata has gpu-device-plugin
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+						Annotations: map[string]string{
+							utils.AnnotationNestedVirt: "enabled",
+						},
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{},
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinit",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserData: `#cloud-config
+# @kubevirt-feature: gpu-device-plugin=nvidia.com/gpu
+users:
+  - name: ubuntu
+`,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				vmBytes, err := json.Marshal(vm)
+				Expect(err).ToNot(HaveOccurred())
+
+				req := &admissionv1.AdmissionRequest{
+					UID:       "test-uid",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: vmBytes,
+					},
+				}
+
+				nestedVirtFeature := features.NewNestedVirtualization(&config.NestedVirtConfig{
+					Enabled:       true,
+					AutoDetectCPU: true,
+				}, utils.ConfigSourceAnnotations)
+				gpuFeature := features.NewGpuDevicePlugin(utils.ConfigSourceAnnotations)
+				mutator = NewMutator(nil, cfg, []features.Feature{nestedVirtFeature, gpuFeature})
+
+				response, err := mutator.Handle(ctx, req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+				Expect(response.Allowed).To(BeTrue())
+				Expect(response.Patch).ToNot(BeNil())
+
+				// Verify both features were applied
+				var patchOps []map[string]interface{}
+				err = json.Unmarshal(response.Patch, &patchOps)
+				Expect(err).ToNot(HaveOccurred())
+
+				foundSpecPatch := false
+				for _, op := range patchOps {
+					if path, ok := op["path"].(string); ok && path == "/spec" {
+						foundSpecPatch = true
+						spec := op["value"].(map[string]interface{})
+						template := spec["template"].(map[string]interface{})
+						specMap := template["spec"].(map[string]interface{})
+						domain := specMap["domain"].(map[string]interface{})
+
+						// Check CPU features from nested virt (from annotation)
+						cpu := domain["cpu"].(map[string]interface{})
+						cpuFeatures := cpu["features"].([]interface{})
+						Expect(cpuFeatures).ToNot(BeEmpty())
+
+						// Check GPU resource limits (from userdata)
+						resources := domain["resources"].(map[string]interface{})
+						limits := resources["limits"].(map[string]interface{})
+						Expect(limits).To(HaveKey("nvidia.com/gpu"))
+						break
+					}
+				}
+				Expect(foundSpecPatch).To(BeTrue())
+
+				// Verify annotations contain both the original and merged annotations
+				for _, op := range patchOps {
+					if path, ok := op["path"].(string); ok && path == "/metadata/annotations" {
+						annotations, ok := op["value"].(map[string]interface{})
+						Expect(ok).To(BeTrue())
+						Expect(annotations).To(HaveKey(utils.AnnotationNestedVirt))
+						Expect(annotations).To(HaveKey(utils.AnnotationGpuDevicePlugin))
+						Expect(annotations).To(HaveKey(utils.AnnotationNestedVirtApplied))
+						Expect(annotations).To(HaveKey(utils.AnnotationGpuDevicePluginApplied))
+						break
+					}
+				}
+			})
+		})
+
+		Context("with invalid userdata", func() {
+			It("should continue with annotation-based features when secret reference fails", func() {
+				// VM references a secret that doesn't exist (parser will fail non-fatally)
+				// The mutator should still process the annotation-based feature
+				scheme := runtime.NewScheme()
+				_ = corev1.AddToScheme(scheme)
+				_ = kubevirtv1.AddToScheme(scheme)
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+						Annotations: map[string]string{
+							utils.AnnotationNestedVirt: "enabled",
+						},
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{},
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinit",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												// Reference a secret that doesn't exist
+												UserDataSecretRef: &corev1.LocalObjectReference{
+													Name: "non-existent-secret",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				vmBytes, err := json.Marshal(vm)
+				Expect(err).ToNot(HaveOccurred())
+
+				req := &admissionv1.AdmissionRequest{
+					UID:       "test-uid",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: vmBytes,
+					},
+				}
+
+				nestedVirtFeature := features.NewNestedVirtualization(&config.NestedVirtConfig{
+					Enabled:       true,
+					AutoDetectCPU: true,
+				}, utils.ConfigSourceAnnotations)
+				mutator = NewMutator(fakeClient, cfg, []features.Feature{nestedVirtFeature})
+
+				response, err := mutator.Handle(ctx, req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+				Expect(response.Allowed).To(BeTrue())
+				Expect(response.Patch).ToNot(BeNil())
+
+				// Verify the annotation-based feature was still applied
+				var patchOps []map[string]interface{}
+				err = json.Unmarshal(response.Patch, &patchOps)
+				Expect(err).ToNot(HaveOccurred())
+
+				foundSpecPatch := false
+				for _, op := range patchOps {
+					if path, ok := op["path"].(string); ok && path == "/spec" {
+						foundSpecPatch = true
+						spec := op["value"].(map[string]interface{})
+						template := spec["template"].(map[string]interface{})
+						specMap := template["spec"].(map[string]interface{})
+						domain := specMap["domain"].(map[string]interface{})
+						cpu := domain["cpu"].(map[string]interface{})
+						cpuFeatures := cpu["features"].([]interface{})
+						Expect(cpuFeatures).ToNot(BeEmpty())
+						break
+					}
+				}
+				Expect(foundSpecPatch).To(BeTrue())
+			})
+
+			It("should allow VM with no features when userdata parsing fails", func() {
+				// VM only has secret ref that fails, no annotations - should allow without mutation
+				scheme := runtime.NewScheme()
+				_ = corev1.AddToScheme(scheme)
+				_ = kubevirtv1.AddToScheme(scheme)
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{},
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinit",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												// Reference a secret that doesn't exist
+												UserDataSecretRef: &corev1.LocalObjectReference{
+													Name: "non-existent-secret",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				vmBytes, err := json.Marshal(vm)
+				Expect(err).ToNot(HaveOccurred())
+
+				req := &admissionv1.AdmissionRequest{
+					UID:       "test-uid",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: vmBytes,
+					},
+				}
+
+				nestedVirtFeature := features.NewNestedVirtualization(&config.NestedVirtConfig{
+					Enabled:       true,
+					AutoDetectCPU: true,
+				}, utils.ConfigSourceAnnotations)
+				mutator = NewMutator(fakeClient, cfg, []features.Feature{nestedVirtFeature})
+
+				response, err := mutator.Handle(ctx, req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+				Expect(response.Allowed).To(BeTrue())
+				// Should have no mutation (no patch) since no features are enabled
+				Expect(response.Result.Message).To(ContainSubstring("No features requested"))
+			})
+
+			It("should handle userdata with features from existing secret", func() {
+				// Test that userdata is successfully parsed from a secret that exists
+				scheme := runtime.NewScheme()
+				_ = corev1.AddToScheme(scheme)
+				_ = kubevirtv1.AddToScheme(scheme)
+
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-userdata-secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"userdata": []byte(`#cloud-config
+# @kubevirt-feature: nested-virt=enabled
+users:
+  - name: ubuntu
+`),
+					},
+				}
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "default",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{},
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinit",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserDataSecretRef: &corev1.LocalObjectReference{
+													Name: "test-userdata-secret",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				vmBytes, err := json.Marshal(vm)
+				Expect(err).ToNot(HaveOccurred())
+
+				req := &admissionv1.AdmissionRequest{
+					UID:       "test-uid",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: vmBytes,
+					},
+				}
+
+				nestedVirtFeature := features.NewNestedVirtualization(&config.NestedVirtConfig{
+					Enabled:       true,
+					AutoDetectCPU: true,
+				}, utils.ConfigSourceAnnotations)
+				mutator = NewMutator(fakeClient, cfg, []features.Feature{nestedVirtFeature})
+
+				response, err := mutator.Handle(ctx, req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+				Expect(response.Allowed).To(BeTrue())
+				Expect(response.Patch).ToNot(BeNil())
+
+				// Verify the feature from secret userdata was applied
+				var patchOps []map[string]interface{}
+				err = json.Unmarshal(response.Patch, &patchOps)
+				Expect(err).ToNot(HaveOccurred())
+
+				foundSpecPatch := false
+				for _, op := range patchOps {
+					if path, ok := op["path"].(string); ok && path == "/spec" {
+						foundSpecPatch = true
+						spec := op["value"].(map[string]interface{})
+						template := spec["template"].(map[string]interface{})
+						specMap := template["spec"].(map[string]interface{})
+						domain := specMap["domain"].(map[string]interface{})
+						cpu := domain["cpu"].(map[string]interface{})
+						cpuFeatures := cpu["features"].([]interface{})
+						Expect(cpuFeatures).ToNot(BeEmpty())
 						break
 					}
 				}


### PR DESCRIPTION
Implement parsing of feature directives from VM userdata,
supporting plain text, base64, and Secret references.
Integrate this functionality into the mutator to enhance
VM feature management based on userdata directives.

Closes #20