### PR TITLE
fix(webhook): reload TLS keypair when the mounted certificate rotates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
+github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=
 github.com/google/gnostic-models v0.7.0/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -131,6 +133,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -5,8 +5,10 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/jaevans/kubevirt-vm-feature-manager/pkg/config"
@@ -36,9 +38,25 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("/healthz", s.healthzHandler)
 	mux.HandleFunc("/readyz", s.readyzHandler)
 
+	certFile := filepath.Join(s.config.CertDir, "tls.crt")
+	keyFile := filepath.Join(s.config.CertDir, "tls.key")
+
+	// Watch the keypair on disk rather than handing the paths to
+	// ListenAndServeTLS, which parses them once and caches the result for the
+	// lifetime of the process. The certificate is mounted from a Secret that
+	// cert-manager rotates well before expiry, so a cached keypair leaves the
+	// webhook serving an expired certificate until someone restarts the pod.
+	// Because the webhook has failurePolicy: Fail, that takes down every
+	// VirtualMachine create in the cluster.
+	certWatcher, err := certwatcher.New(certFile, keyFile)
+	if err != nil {
+		return fmt.Errorf("failed to load TLS keypair from %s: %w", s.config.CertDir, err)
+	}
+
 	// Configure TLS
 	tlsConfig := &tls.Config{
-		MinVersion: tls.VersionTLS12,
+		MinVersion:     tls.VersionTLS12,
+		GetCertificate: certWatcher.GetCertificate,
 	}
 
 	s.server = &http.Server{
@@ -54,13 +72,22 @@ func (s *Server) Start(ctx context.Context) error {
 		"port", s.config.Port,
 		"certDir", s.config.CertDir)
 
-	// Start server in a goroutine
-	errChan := make(chan error, 1)
-	go func() {
-		certFile := fmt.Sprintf("%s/tls.crt", s.config.CertDir)
-		keyFile := fmt.Sprintf("%s/tls.key", s.config.CertDir)
+	errChan := make(chan error, 2)
 
-		if err := s.server.ListenAndServeTLS(certFile, keyFile); err != nil && err != http.ErrServerClosed {
+	// Reload the keypair on change. certwatcher combines fsnotify events with
+	// periodic polling, so it survives the atomic symlink swap kubelet uses
+	// when updating a mounted Secret.
+	go func() {
+		if err := certWatcher.Start(ctx); err != nil {
+			errChan <- fmt.Errorf("certificate watcher failed: %w", err)
+		}
+	}()
+
+	// Start server in a goroutine
+	go func() {
+		// The keypair is supplied by tlsConfig.GetCertificate, so the file
+		// arguments are intentionally empty.
+		if err := s.server.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
 			errChan <- err
 		}
 	}()

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -2,8 +2,20 @@ package webhook
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -137,4 +149,113 @@ var _ = Describe("Server", func() {
 			})
 		})
 	})
+
+	Describe("TLS certificate rotation", func() {
+		var (
+			certDir string
+			addr    string
+			cancel  context.CancelFunc
+			errChan chan error
+		)
+
+		BeforeEach(func() {
+			certDir = GinkgoT().TempDir()
+			writeSelfSignedCertPair(certDir, "original.example.com")
+
+			port := freeLocalPort()
+			addr = fmt.Sprintf("127.0.0.1:%d", port)
+			cfg.Port = port
+			cfg.CertDir = certDir
+
+			var ctx context.Context
+			ctx, cancel = context.WithCancel(context.Background())
+
+			errChan = make(chan error, 1)
+			go func() {
+				errChan <- server.Start(ctx)
+			}()
+
+			// Don't start asserting until the listener is actually serving TLS.
+			Eventually(func() (string, error) {
+				return servedCertCommonName(addr)
+			}, "10s", "100ms").Should(Equal("original.example.com"))
+		})
+
+		AfterEach(func() {
+			cancel()
+			Eventually(errChan, "10s").Should(Receive())
+		})
+
+		It("should serve the new certificate after the files on disk are replaced", func() {
+			writeSelfSignedCertPair(certDir, "rotated.example.com")
+
+			Eventually(func() (string, error) {
+				return servedCertCommonName(addr)
+			}, "30s", "250ms").Should(Equal("rotated.example.com"))
+		})
+	})
 })
+
+// freeLocalPort reserves an ephemeral port and releases it so the server under
+// test can bind it.
+func freeLocalPort() int {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	Expect(err).ToNot(HaveOccurred())
+	port := listener.Addr().(*net.TCPAddr).Port
+	Expect(listener.Close()).To(Succeed())
+	return port
+}
+
+// servedCertCommonName connects to addr and reports the common name of the
+// leaf certificate the server presents.
+func servedCertCommonName(addr string) (string, error) {
+	conn, err := tls.Dial("tcp", addr, &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec // test asserts on the presented cert, not its trust chain
+		MinVersion:         tls.VersionTLS12,
+	})
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = conn.Close() }()
+
+	certs := conn.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		return "", fmt.Errorf("server presented no certificates")
+	}
+	return certs[0].Subject.CommonName, nil
+}
+
+// writeSelfSignedCertPair writes a self-signed tls.crt/tls.key pair for
+// commonName into dir, replacing any existing pair.
+func writeSelfSignedCertPair(dir, commonName string) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	Expect(err).ToNot(HaveOccurred())
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	Expect(err).ToNot(HaveOccurred())
+
+	template := x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	Expect(err).ToNot(HaveOccurred())
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	Expect(err).ToNot(HaveOccurred())
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	// Write the key before the cert so a watcher that reacts to the cert
+	// change always finds a matching key already in place.
+	Expect(os.WriteFile(filepath.Join(dir, "tls.key"), keyPEM, 0o600)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(dir, "tls.crt"), certPEM, 0o600)).To(Succeed())
+}


### PR DESCRIPTION
## Problem

`pkg/webhook/server.go` passed cert/key paths to `http.Server.ListenAndServeTLS`, which parses them **once** and caches the keypair for the lifetime of the process. The certificate is mounted from a Secret that cert-manager rotates ahead of expiry, so after a rotation the server kept presenting the superseded leaf — and eventually an expired one.

Since the `MutatingWebhookConfiguration` uses `failurePolicy: Fail` on `CREATE`/`UPDATE` of `virtualmachines`, an expired certificate blocks **every VM create in the cluster**.

This is not hypothetical — it took down VM provisioning on a live Harvester cluster:

- cert-manager issued a replacement at `2026-07-13T19:43:13Z` (`duration: 2160h`, `renewBefore: 360h`)
- both webhook pods had started `2026-07-10`, so they never picked it up
- the old leaf expired `2026-07-28T19:43:13Z` while they were still serving it

Downstream, the Rancher Harvester node driver failed every machine create:

```
error creating machine: error in driver during machine creation: Internal error occurred:
failed calling webhook "vm-feature-manager.vm-feature-manager.svc": failed to call webhook:
Post "https://vm-feature-manager-webhook.vm-feature-manager.svc:443/mutate?timeout=10s":
tls: failed to verify certificate: x509: certificate has expired or is not yet valid:
current time 2026-07-29T12:47:03Z is after 2026-07-28T19:43:13Z
```

which in turn stalled cluster-autoscaler scale-ups and failed CI jobs whose runner pods could not be scheduled.

## Fix

Supply the keypair via `tls.Config.GetCertificate`, backed by `sigs.k8s.io/controller-runtime/pkg/certwatcher`.

`certwatcher` combines fsnotify events with a periodic poll (10s default), which matters here: kubelet updates a mounted Secret by atomically swapping the `..data` symlink, and a naive fsnotify-on-file watch misses that.

A watcher that fails to start is returned as an error, which `main()` already treats as fatal (`os.Exit(1)`), so the pod restarts rather than silently continuing on a static keypair.

`certwatcher` comes from the `controller-runtime` module already in use, so this adds no new **direct** dependency — one new indirect (`github.com/fsnotify/fsnotify v1.9.0`).

## Tests

Added `TLS certificate rotation` to `pkg/webhook/server_test.go`: generate a self-signed pair, start the server, TLS-dial and assert the presented CN, rewrite the files with a new CN, assert the new one is served.

Confirmed it fails against the old code before implementing the fix:

```
[FAILED] Timed out after 30.004s.
Expected
    <string>: original.example.com
to equal
    <string>: rotated.example.com
```

With the fix it passes in 0.136s — the rotation is picked up on the fsnotify event, not the poll fallback.

## Verification

| Check | Result |
|---|---|
| `go vet ./...` | OK |
| `golangci-lint run ./...` | 0 issues |
| Unit suite (all packages) | all `ok` |
| `pkg/webhook` uncached (44 specs) | `ok 0.263s` |
| Integration suite (envtest 1.33.0) | `ok 3.314s` |

## Deadline

Restarting the pods restored service, so they now hold the current certificate (valid to `2026-10-11T19:43:13Z`). cert-manager will issue the next revision at `renewalTime 2026-09-26T19:43:13Z`, which the deployed image still won't reload — **the same outage recurs on 2026-10-11** unless a release ships before then.

## Follow-up

`readyzHandler` returns 200 unconditionally, which is why this outage stayed invisible for ~17 hours. Making readiness reflect the served certificate is handled in a separate stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)