### PR TITLE
fix(webhook): report unready when the served certificate is invalid

### DIFF
--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -16,9 +17,10 @@ import (
 
 // Server represents the webhook HTTP server
 type Server struct {
-	config  *config.Config
-	handler *Handler
-	server  *http.Server
+	config      *config.Config
+	handler     *Handler
+	server      *http.Server
+	certWatcher *certwatcher.CertWatcher
 }
 
 // NewServer creates a new webhook server
@@ -52,6 +54,7 @@ func (s *Server) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to load TLS keypair from %s: %w", s.config.CertDir, err)
 	}
+	s.certWatcher = certWatcher
 
 	// Configure TLS
 	tlsConfig := &tls.Config{
@@ -113,11 +116,63 @@ func (s *Server) healthzHandler(w http.ResponseWriter, _ *http.Request) {
 	}
 }
 
-// readyzHandler handles readiness check requests
+// readyzHandler handles readiness check requests. Readiness reflects whether
+// the webhook can currently complete a TLS handshake, so that a certificate
+// problem takes this replica out of the Service instead of silently failing
+// every VirtualMachine admission that lands on it.
 func (s *Server) readyzHandler(w http.ResponseWriter, _ *http.Request) {
+	if err := s.certificateReady(time.Now()); err != nil {
+		log.Log.Error(err, "Readiness check failed")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		if _, werr := w.Write([]byte("not ready: " + err.Error())); werr != nil {
+			// Log error but don't fail - response status already sent
+			log.Log.Error(werr, "Failed to write readiness check response")
+		}
+		return
+	}
+
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write([]byte("ready")); err != nil {
 		// Log error but don't fail - response status already sent
 		log.Log.Error(err, "Failed to write readiness check response")
 	}
+}
+
+// certificateReady reports whether the certificate the server would currently
+// present is loaded and within its validity window at now.
+func (s *Server) certificateReady(now time.Time) error {
+	if s.certWatcher == nil {
+		return fmt.Errorf("no certificate loaded")
+	}
+
+	// GetCertificate never returns an error today, but it is documented as
+	// possibly returning a nil certificate.
+	cert, err := s.certWatcher.GetCertificate(nil)
+	if err != nil {
+		return fmt.Errorf("could not read current certificate: %w", err)
+	}
+	if cert == nil {
+		return fmt.Errorf("no certificate loaded")
+	}
+
+	// Leaf is populated by tls.X509KeyPair on current Go versions, but parse it
+	// from the DER as a fallback so readiness never depends on that detail.
+	leaf := cert.Leaf
+	if leaf == nil {
+		if len(cert.Certificate) == 0 {
+			return fmt.Errorf("current certificate contains no data")
+		}
+		if leaf, err = x509.ParseCertificate(cert.Certificate[0]); err != nil {
+			return fmt.Errorf("could not parse current certificate: %w", err)
+		}
+	}
+
+	if now.After(leaf.NotAfter) {
+		return fmt.Errorf("certificate expired at %s", leaf.NotAfter.Format(time.RFC3339))
+	}
+	if now.Before(leaf.NotBefore) {
+		return fmt.Errorf("certificate is not valid until %s", leaf.NotBefore.Format(time.RFC3339))
+	}
+
+	return nil
 }

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -21,6 +21,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+
 	"github.com/jaevans/kubevirt-vm-feature-manager/pkg/config"
 	"github.com/jaevans/kubevirt-vm-feature-manager/pkg/features"
 )
@@ -82,21 +84,71 @@ var _ = Describe("Server", func() {
 		})
 
 		Describe("readyzHandler", func() {
-			It("should return ready status", func() {
-				req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
-				server.readyzHandler(recorder, req)
+			Context("when the served certificate is valid", func() {
+				BeforeEach(func() {
+					certDir := GinkgoT().TempDir()
+					writeSelfSignedCertPair(certDir, "ready.example.com")
+					loadCertWatcher(server, certDir)
+				})
 
-				Expect(recorder.Code).To(Equal(http.StatusOK))
-				Expect(recorder.Body.String()).To(Equal("ready"))
+				It("should return ready status", func() {
+					req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+					server.readyzHandler(recorder, req)
+
+					Expect(recorder.Code).To(Equal(http.StatusOK))
+					Expect(recorder.Body.String()).To(Equal("ready"))
+				})
+
+				It("should handle write errors gracefully", func() {
+					// Test that the handler completes even if write fails
+					req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+					recorder := httptest.NewRecorder()
+					server.readyzHandler(recorder, req)
+
+					Expect(recorder.Code).To(Equal(http.StatusOK))
+				})
 			})
 
-			It("should handle write errors gracefully", func() {
-				// Test that the handler completes even if write fails
-				req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
-				recorder := httptest.NewRecorder()
-				server.readyzHandler(recorder, req)
+			Context("when the served certificate has expired", func() {
+				BeforeEach(func() {
+					certDir := GinkgoT().TempDir()
+					writeSelfSignedCertPairWithValidity(certDir, "expired.example.com",
+						time.Now().Add(-48*time.Hour), time.Now().Add(-time.Hour))
+					loadCertWatcher(server, certDir)
+				})
 
-				Expect(recorder.Code).To(Equal(http.StatusOK))
+				It("should not report ready", func() {
+					req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+					server.readyzHandler(recorder, req)
+
+					Expect(recorder.Code).To(Equal(http.StatusServiceUnavailable))
+					Expect(recorder.Body.String()).To(ContainSubstring("expired"))
+				})
+			})
+
+			Context("when the served certificate is not yet valid", func() {
+				BeforeEach(func() {
+					certDir := GinkgoT().TempDir()
+					writeSelfSignedCertPairWithValidity(certDir, "future.example.com",
+						time.Now().Add(time.Hour), time.Now().Add(48*time.Hour))
+					loadCertWatcher(server, certDir)
+				})
+
+				It("should not report ready", func() {
+					req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+					server.readyzHandler(recorder, req)
+
+					Expect(recorder.Code).To(Equal(http.StatusServiceUnavailable))
+				})
+			})
+
+			Context("when no certificate has been loaded", func() {
+				It("should not report ready", func() {
+					req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+					server.readyzHandler(recorder, req)
+
+					Expect(recorder.Code).To(Equal(http.StatusServiceUnavailable))
+				})
 			})
 		})
 	})
@@ -196,6 +248,14 @@ var _ = Describe("Server", func() {
 	})
 })
 
+// loadCertWatcher points the server at the keypair in dir, as Start would, so
+// readiness checks can inspect the certificate it would serve.
+func loadCertWatcher(server *Server, dir string) {
+	watcher, err := certwatcher.New(filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key"))
+	Expect(err).ToNot(HaveOccurred())
+	server.certWatcher = watcher
+}
+
 // freeLocalPort reserves an ephemeral port and releases it so the server under
 // test can bind it.
 func freeLocalPort() int {
@@ -225,9 +285,17 @@ func servedCertCommonName(addr string) (string, error) {
 	return certs[0].Subject.CommonName, nil
 }
 
-// writeSelfSignedCertPair writes a self-signed tls.crt/tls.key pair for
-// commonName into dir, replacing any existing pair.
+// writeSelfSignedCertPair writes a currently-valid self-signed tls.crt/tls.key
+// pair for commonName into dir, replacing any existing pair.
 func writeSelfSignedCertPair(dir, commonName string) {
+	writeSelfSignedCertPairWithValidity(dir, commonName,
+		time.Now().Add(-time.Hour), time.Now().Add(24*time.Hour))
+}
+
+// writeSelfSignedCertPairWithValidity writes a self-signed tls.crt/tls.key pair
+// for commonName into dir with an explicit validity window, replacing any
+// existing pair.
+func writeSelfSignedCertPairWithValidity(dir, commonName string, notBefore, notAfter time.Time) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -237,8 +305,8 @@ func writeSelfSignedCertPair(dir, commonName string) {
 	template := x509.Certificate{
 		SerialNumber: serial,
 		Subject:      pkix.Name{CommonName: commonName},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(24 * time.Hour),
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
 		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		DNSNames:     []string{"localhost"},


### PR DESCRIPTION
> **Stacked on #42** — targets `fix/webhook-tls-cert-hot-reload`, not `main`. It needs the `certWatcher` that #42 introduces, because readiness has to inspect the certificate actually being *served*, not whatever happens to be on disk. Please merge #42 first; this PR will then retarget `main` automatically.

## Problem

`readyzHandler` returned 200 unconditionally. A replica presenting an expired or unparseable certificate therefore stayed in the Service endpoints and failed every VirtualMachine admission routed to it.

With `failurePolicy: Fail` that is a cluster-wide outage that produces **no signal on the pod itself** — it looks perfectly healthy. In the incident behind #42 the certificate expired at `2026-07-28T19:43:13Z` and the problem only surfaced through a failed CI job at `2026-07-29T11:33:29Z`, roughly sixteen hours later. Both pods were `1/1 Running` and `Ready` throughout.

## Fix

Readiness now reflects the certificate the server would actually present. A replica reports `503` when:

- no certificate has been loaded
- the leaf cannot be parsed
- the current time falls outside the leaf's validity window (expired, or not yet valid)

The reason is included in the response body, so `kubectl describe pod` explains the failure rather than just reporting a failed probe.

Two details worth calling out:

- `certwatcher.GetCertificate` is documented as possibly returning a **nil certificate with a nil error**, so the nil check is on the certificate, not the error.
- `Certificate.Leaf` is populated by `tls.X509KeyPair` on current Go versions, but the DER is parsed as a fallback so readiness never silently depends on that.

### Liveness is deliberately left unconditional

Restarting on certificate expiry would paper over the cause, and risks crash-looping when cert-manager cannot issue at all. Readiness removes the endpoint from the Service while leaving the pod inspectable, which is the behaviour you want during a certificate problem.

## Tests

Added to the `readyzHandler` specs: valid certificate, expired certificate, not-yet-valid certificate, and no certificate loaded. Confirmed the three new specs fail against the unconditional handler before implementing:

```
Summarizing 3 Failures:
  [FAIL] readyzHandler when the served certificate has expired [It] should not report ready
  [FAIL] readyzHandler when the served certificate is not yet valid [It] should not report ready
  [FAIL] readyzHandler when no certificate has been loaded [It] should not report ready
Ran 5 of 47 Specs -- 2 Passed | 3 Failed
```

The two pre-existing valid-certificate specs passed throughout, so the happy path is unchanged.

## Verification

| Check | Result |
|---|---|
| `go vet ./...` | OK |
| `golangci-lint run ./...` | 0 issues |
| Unit suite (all packages) | all `ok` |
| `pkg/webhook` uncached (47 specs) | `ok 0.260s` |
| Integration suite (envtest 1.33.0) | `ok 3.803s` |

## Note on CI

The `Test` job currently fails on both this PR and #42 for an unrelated, pre-existing reason: the workflow pins `go-version: '1.25'` while `setup-envtest@latest` now resolves to `v0.24.1`, which requires Go >= 1.26.

```
setup-envtest@v0.24.1 requires go >= 1.26.0 (running go 1.25.12; GOTOOLCHAIN=local)
```

Because `@latest` floats, this affects every open PR, not just these. #34 already bumps both workflows to `'1.26'` and resolves it — no duplicate change made here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)