### PR TITLE
fix(release): update signing config for cosign v3 bundle format

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -105,31 +105,27 @@ sboms:
       - webhook
 
 # Sign artifacts (disabled in snapshot mode)
+# cosign v3 bundle format: signature and certificate in one .sigstore.json file
 signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
-    certificate: '${artifact}.pem'
+    signature: '${artifact}.sigstore.json'
     args:
       - sign-blob
-      - '--output-certificate=${certificate}'
-      - '--output-signature=${signature}'
+      - '--bundle=${signature}'
       - '${artifact}'
-      - "--yes" # needed on cosign 2.0.0+
+      - '--yes'
     artifacts: checksum
     output: true
 
 # Docker image signing (disabled in snapshot mode)
 docker_signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
     artifacts: all
     output: true
     args:
       - 'sign'
       - '${artifact}'
-      - "--yes" # needed on cosign 2.0.0+
+      - '--yes'
 
 # Release notes
 release:


### PR DESCRIPTION
## Summary
- The v0.2.0 release run failed in the signing phase ([run 30486597076](https://github.com/jaevans/kubevirt-vm-feature-manager/actions/runs/30486597076)). The immediate error was a transient GitHub OIDC endpoint failure, but the run log also revealed a latent config bug: since #48 bumped cosign-installer to v4 (cosign v3), `--output-signature`/`--output-certificate` are ignored under the new default bundle format, so the declared `.sig`/`.pem` artifacts would never be written.
- Switch `signs` to cosign v3's single-bundle output (`checksums.txt.sigstore.json`) per [goreleaser's migration guidance](https://goreleaser.com/blog/cosign-v3/).
- Drop the obsolete `COSIGN_EXPERIMENTAL=1` env (no-op since cosign 2.0).

## Verification
- `goreleaser check` passes.
- After merge, v0.2.0 will be re-tagged; the release should contain `checksums.txt.sigstore.json`, verifiable with `cosign verify-blob --bundle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)