### PR TITLE
ci(release): pin goreleaser version to '~> v2'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: latest
+          version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- The v0.2.0 release run annotated a warning from goreleaser-action: `You are using 'latest' as default version. Will lock to '~> v2'.`
- Pin `version: '~> v2'` explicitly; Renovate will handle future major version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)